### PR TITLE
Add inline editing of title and body

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'teaspoon'
   gem 'teaspoon-mocha'
+  gem 'chromedriver-helper'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (6.0.3)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -58,6 +60,9 @@ GEM
       xpath (~> 2.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.0.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -81,6 +86,7 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
+    io-like (0.3.0)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -218,6 +224,7 @@ DEPENDENCIES
   browserify-rails
   byebug
   capybara
+  chromedriver-helper
   coffee-rails (~> 4.1.0)
   database_cleaner
   factory_girl_rails

--- a/app/assets/javascripts/idea.js.es6
+++ b/app/assets/javascripts/idea.js.es6
@@ -1,8 +1,8 @@
 class Idea {
   newIdea(data) {
     return $(`<li data-id="${data.id}">
-        <h1>${data.title}</h1>
-        <h2>${data.body}</h2>
+        <h1 class="idea-title" contenteditable="true">${data.title}</h1>
+        <h2 class="idea-body" contenteditable="true">${data.body}</h2>
         <h3>${data.quality}</h3>
         <a href="#" class="delete-idea">Delete</a>
         <a href="#" class="thumbs_up"><img src="/assets/thumbs_up.png"></a>
@@ -24,6 +24,26 @@ class Idea {
       dataType: 'json',
       method: 'PUT',
       url: `/api/v1/ideas/${$quality.parent().data('id')}`
+    });
+  }
+
+  updateTitle($title) {
+    let ideaId = $title.parent().data('id');
+    $.ajax({
+      data: { idea: { title: $title.text() } },
+      dataType: 'json',
+      method: 'PUT',
+      url: `/api/v1/ideas/${ideaId}`
+    });
+  }
+
+  updateBody($body) {
+    let ideaId = $body.parent().data('id');
+    $.ajax({
+      data: { idea: { body: $body.text() } },
+      dataType: 'json',
+      method: 'PUT',
+      url: `/api/v1/ideas/${ideaId}`
     });
   }
 

--- a/app/assets/javascripts/main.js.es6
+++ b/app/assets/javascripts/main.js.es6
@@ -32,3 +32,17 @@ $(document).on('click', '.thumbs_down', function(e) {
   Quality.decrement($quality);
   idea.updateData($quality);
 });
+
+$(document).on('keydown', '.idea-title', function(e) {
+  if (e.keyCode === 13) {
+    e.preventDefault();
+    idea.updateTitle($(this));
+  }
+});
+
+$(document).on('keydown', '.idea-body', function(e) {
+  if (e.keyCode === 13) {
+    e.preventDefault();
+    idea.updateBody($(this));
+  }
+});

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -6,8 +6,8 @@
   <% else %>
     <% @ideas.each do |idea| %>
       <li data-id=<%= idea.id %>>
-        <h1><%= idea.title %></h1>
-        <h2><%= idea.body %></h2>
+        <h1 class='idea-title' contenteditable='true'><%= idea.title %></h1>
+        <h2 class='idea-body' contenteditable='true'><%= idea.body %></h2>
         <h3><%= idea.quality %></h3>
         <%= link_to 'Delete', '#', class: 'delete-idea' %>
         <%= link_to image_tag('thumbs_up', alt: 'thumbs up'), '#', class: 'thumbs_up' %>

--- a/spec/features/user_can_edit_an_existing_idea_spec.rb
+++ b/spec/features/user_can_edit_an_existing_idea_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'User can edit an existing idea' do
+  scenario 'the title is updated in the browser and persisted', js: true do
+    create(:idea)
+
+    visit root_path
+    title = find('.idea-title')
+    title.set('JS is the BEST')
+    title.native.send_keys(:return)
+
+    expect(page).to have_content('JS is the BEST')
+
+    visit root_path
+
+    expect(page).to have_content('JS is the BEST')
+  end
+
+  scenario 'the body is updated in the browser and persisted', js: true do
+    create(:idea)
+
+    visit root_path
+    title = find('.idea-body')
+    title.set('JS is the SUPER BEST')
+    title.native.send_keys(:return)
+
+    expect(page).to have_content('JS is the SUPER BEST')
+
+    visit root_path
+
+    expect(page).to have_content('JS is the SUPER BEST')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,12 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, :browser => :chrome)
+end
+
+Capybara.javascript_driver = :chrome
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
Using contenteditable the user can now update the contents of the title
and body inline. When the user presses enter, the content is also updated
in the browser.

Closes #15
